### PR TITLE
Add --no-series and --no-movie options

### DIFF
--- a/source/arguments.cpp
+++ b/source/arguments.cpp
@@ -29,6 +29,8 @@ static constexpr const char* VERSION = "1.4.3";
 #define ARG_STOP_ON_ERROR                   "--stop-on-error"
 #define ARG_SUBTITLE_LANGS                  "--subtitle-langs"
 #define ARG_SKIP_NCOP_NCED                  "--skip-ncop-nced"
+#define ARG_NO_SERIES                       "--no-series"
+#define ARG_NO_MOVIE                        "--no-movie"
 #define ARG_SUBTITLE_DELAY                  "--subtitle-delay"
 #define ARG_PREFER_SDH_SUBS                 "--prefer-sdh-subs"
 #define ARG_PREFER_TEXT_SUBS                "--prefer-text-subs"
@@ -66,6 +68,14 @@ static void setupMap()
 
 	helpList.push_back({ ARG_TAG,
 		"enable metadata tagging"
+	});
+
+	helpList.push_back({ ARG_NO_SERIES,
+		"disable TV series metadata search, only try movies"
+	});
+
+	helpList.push_back({ ARG_NO_MOVIE,
+		"disable movie metadata search, only try TV series"
 	});
 
 	helpList.push_back({ ARG_SUBTITLE_DELAY,
@@ -515,6 +525,16 @@ namespace args
 				else if(!strcmp(argv[i], ARG_SKIP_NCOP_NCED))
 				{
 					config::setSkipNCOPNCED(true);
+					continue;
+				}
+				else if(!strcmp(argv[i], ARG_NO_SERIES))
+				{
+					config::setDisableSeriesSearch(true);
+					continue;
+				}
+				else if(!strcmp(argv[i], ARG_NO_MOVIE))
+				{
+					config::setDisableMovieSearch(true);
 					continue;
 				}
 				else if(!strcmp(argv[i], ARG_RENAME_WITH_EPISODE_TITLE))

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -254,6 +254,8 @@ namespace config
 	static bool stopOnError = false;
 	static bool renameFiles = false;
 	static bool skipNCOPNCED = false;
+	static bool noSeriesSearch = false;
+	static bool noMovieSearch = false;
 	static bool preferEnglishTitle = false;
 	static bool noSmartReplaceCoverArt = false;
 	static bool renameWithoutEpisodeTitle = false;
@@ -311,6 +313,8 @@ namespace config
 	bool isPreferOneStream()                { return preferOneStream; }
 	bool isPreferSignSongSubs()             { return preferSignSongSubs; }
 	bool shouldSkipNCOPNCED()               { return skipNCOPNCED; }
+	bool disableSeriesSearch()              { return noSeriesSearch; }
+	bool disableMovieSearch()               { return noMovieSearch; }
 	int getSeasonNumber()                   { return manualSeasonNumber; }
 	int getEpisodeNumber()                  { return manualEpisodeNumber; }
 	double getSubtitleDelay()               { return subtitleDelay; }
@@ -344,6 +348,8 @@ namespace config
 	void setPreferOneStream(bool x)                 { preferOneStream = x; }
 	void setPreferSignSongSubs(bool x)              { preferSignSongSubs = x; }
 	void setSkipNCOPNCED(bool x)                    { skipNCOPNCED = x; }
+	void setDisableSeriesSearch(bool x)             { noSeriesSearch = x; }
+	void setDisableMovieSearch(bool x)              { noMovieSearch = x; }
 	void setSeasonNumber(int x)                     { manualSeasonNumber = x; }
 	void setEpisodeNumber(int x)                    { manualEpisodeNumber = x; }
 	void setSubtitleDelay(double x)                 { subtitleDelay = x; }

--- a/source/include/defs.h
+++ b/source/include/defs.h
@@ -224,6 +224,9 @@ namespace config
 
 	bool shouldSkipNCOPNCED();
 
+	bool disableSeriesSearch();
+	bool disableMovieSearch();
+
 	bool isDryRun();
 	bool disableProgress();
 	bool shouldRenameFiles();
@@ -250,6 +253,8 @@ namespace config
 	void setPreferOneStream(bool x);
 	void setPreferSignSongSubs(bool x);
 	void setSkipNCOPNCED(bool x);
+	void setDisableSeriesSearch(bool x);
+	void setDisableMovieSearch(bool x);
 	void setSeasonNumber(int x);
 	void setEpisodeNumber(int x);
 

--- a/source/tagging/driver.cpp
+++ b/source/tagging/driver.cpp
@@ -106,7 +106,7 @@ namespace tag
 		std::vector<std::string>& coverArtNames)
 	{
 		// try tv series
-		if(!config::getManualSeriesId().empty() || config::getManualMovieId().empty())
+		if(!config::disableSeriesSearch() && (!config::getManualSeriesId().empty() || config::getManualMovieId().empty()))
 		{
 			auto [ series, season, episode, title ] = parseTVShow(filepath.stem().string());
 
@@ -160,7 +160,7 @@ namespace tag
 		}
 
 
-		if(!config::getManualMovieId().empty() || config::getManualSeriesId().empty())
+		if(!config::disableMovieSearch() && (!config::getManualMovieId().empty() || config::getManualSeriesId().empty()))
 		{
 			// try movie
 			auto [ title, year ] = parseMovie(filepath.stem().string());


### PR DESCRIPTION
TV series detection will turn up false positives (for example, file named "Apollo 13 (1995).mkv will be detected as a TV series) and the wrong metadata search will happen. In this patch, I added --no-series and --no-movie options, so if you're sure what you are tagging is a movie you can specify --no-series and skip the TV series detection.