### PR TITLE
Add --download-cover and --force-download-cover options

### DIFF
--- a/source/arguments.cpp
+++ b/source/arguments.cpp
@@ -31,6 +31,8 @@ static constexpr const char* VERSION = "1.4.3";
 #define ARG_SKIP_NCOP_NCED                  "--skip-ncop-nced"
 #define ARG_NO_SERIES                       "--no-series"
 #define ARG_NO_MOVIE                        "--no-movie"
+#define ARG_DOWNLOAD_COVER                  "--download-cover"
+#define ARG_FORCE_DOWNLOAD_COVER            "--force-download-cover"
 #define ARG_SUBTITLE_DELAY                  "--subtitle-delay"
 #define ARG_PREFER_SDH_SUBS                 "--prefer-sdh-subs"
 #define ARG_PREFER_TEXT_SUBS                "--prefer-text-subs"
@@ -169,6 +171,14 @@ static void setupMap()
 
 	helpList.push_back({ ARG_NO_AUTO_COVER,
 		"do not automatically detect cover art in the current folder"
+	});
+
+	helpList.push_back({ ARG_DOWNLOAD_COVER,
+		"download cover art from metadata API if no local cover exists and file has no embedded cover"
+	});
+
+	helpList.push_back({ ARG_FORCE_DOWNLOAD_COVER,
+		"download cover art from metadata API, overriding any existing local or embedded cover"
 	});
 
 	helpList.push_back({ ARG_STOP_ON_ERROR,
@@ -535,6 +545,17 @@ namespace args
 				else if(!strcmp(argv[i], ARG_NO_MOVIE))
 				{
 					config::setDisableMovieSearch(true);
+					continue;
+				}
+				else if(!strcmp(argv[i], ARG_DOWNLOAD_COVER))
+				{
+					config::setShouldDownloadCover(true);
+					continue;
+				}
+				else if(!strcmp(argv[i], ARG_FORCE_DOWNLOAD_COVER))
+				{
+					config::setShouldForceDownloadCover(true);
+					config::setShouldDownloadCover(true);
 					continue;
 				}
 				else if(!strcmp(argv[i], ARG_RENAME_WITH_EPISODE_TITLE))

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -256,6 +256,8 @@ namespace config
 	static bool skipNCOPNCED = false;
 	static bool noSeriesSearch = false;
 	static bool noMovieSearch = false;
+	static bool downloadCover = false;
+	static bool forceDownloadCover = false;
 	static bool preferEnglishTitle = false;
 	static bool noSmartReplaceCoverArt = false;
 	static bool renameWithoutEpisodeTitle = false;
@@ -315,6 +317,8 @@ namespace config
 	bool shouldSkipNCOPNCED()               { return skipNCOPNCED; }
 	bool disableSeriesSearch()              { return noSeriesSearch; }
 	bool disableMovieSearch()               { return noMovieSearch; }
+	bool shouldDownloadCover()              { return downloadCover; }
+	bool shouldForceDownloadCover()         { return forceDownloadCover; }
 	int getSeasonNumber()                   { return manualSeasonNumber; }
 	int getEpisodeNumber()                  { return manualEpisodeNumber; }
 	double getSubtitleDelay()               { return subtitleDelay; }
@@ -350,6 +354,8 @@ namespace config
 	void setSkipNCOPNCED(bool x)                    { skipNCOPNCED = x; }
 	void setDisableSeriesSearch(bool x)             { noSeriesSearch = x; }
 	void setDisableMovieSearch(bool x)              { noMovieSearch = x; }
+	void setShouldDownloadCover(bool x)             { downloadCover = x; }
+	void setShouldForceDownloadCover(bool x)        { forceDownloadCover = x; }
 	void setSeasonNumber(int x)                     { manualSeasonNumber = x; }
 	void setEpisodeNumber(int x)                    { manualEpisodeNumber = x; }
 	void setSubtitleDelay(double x)                 { subtitleDelay = x; }

--- a/source/include/defs.h
+++ b/source/include/defs.h
@@ -226,6 +226,8 @@ namespace config
 
 	bool disableSeriesSearch();
 	bool disableMovieSearch();
+	bool shouldDownloadCover();
+	bool shouldForceDownloadCover();
 
 	bool isDryRun();
 	bool disableProgress();
@@ -255,6 +257,8 @@ namespace config
 	void setSkipNCOPNCED(bool x);
 	void setDisableSeriesSearch(bool x);
 	void setDisableMovieSearch(bool x);
+	void setShouldDownloadCover(bool x);
+	void setShouldForceDownloadCover(bool x);
 	void setSeasonNumber(int x);
 	void setEpisodeNumber(int x);
 
@@ -340,6 +344,7 @@ namespace tag
 		std::string normalTitle;
 		std::string canonicalTitle;
 		std::string episodeTitle;
+		std::string coverUrl;
 	};
 
 	struct SeriesMetadata : GenericMetadata

--- a/source/tagging/driver.cpp
+++ b/source/tagging/driver.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 
 #include "defs.h"
+#include "cpr/cpr.h"
 
 #include "picojson.h"
 namespace pj = picojson;
@@ -39,6 +40,7 @@ namespace tag
 
 		std::string extractedFile;
 		bool doNotReattach = false;
+		bool isCoverArt = false;
 	};
 
 	static TmpAttachment extractFirstAttachmentIfNecessary(const std::fs::path& filepath, std::vector<std::string>& cleanupList)
@@ -78,10 +80,12 @@ namespace tag
 
 				// if this is already a cover image, then just replace it -- we don't need to extract and
 				// reattach it. prevents cover art from spamming the file when you run mkvtaginator multiple times.
-				if(!config::disableSmartReplaceCoverArt() && util::match(attachment.mime, "image/jpeg", "image/png")
+				if(util::match(attachment.mime, "image/jpeg", "image/png")
 					&& util::match(attachment.name, "cover", "cover.jpg", "cover.jpeg", "cover.png"))
 				{
-					attachment.doNotReattach = true;
+					attachment.isCoverArt = true;
+					if(!config::disableSmartReplaceCoverArt())
+						attachment.doNotReattach = true;
 				}
 				else if(!config::isDryRun())
 				{
@@ -400,6 +404,35 @@ namespace tag
 		// get the cover art
 		{
 			auto cover = findCoverArt(filepath, coverArtNames);
+
+			// download cover art if enabled and appropriate
+			if(!meta.coverUrl.empty() && config::shouldDownloadCover()
+				&& ((cover.empty() && !firstAttachment.isCoverArt) || config::shouldForceDownloadCover()))
+			{
+				if(config::isDryRun())
+				{
+					util::log("dryrun: would download cover art from '%s'", meta.coverUrl);
+				}
+				else
+				{
+					util::info("downloading cover art...");
+					auto r = cpr::Get(cpr::Url(meta.coverUrl));
+					if(r.status_code == 200 && !r.text.empty())
+					{
+						auto ext = (meta.coverUrl.find(".png") != std::string::npos) ? "png" : "jpg";
+						auto tmpCover = zpr::sprint(".tmp-mkvinator-cover.%s", ext);
+						std::ofstream out(tmpCover, std::ios::binary);
+						out.write(r.text.data(), r.text.size());
+						out.close();
+						cover = tmpCover;
+						filesToCleanup.push_back(tmpCover);
+					}
+					else
+					{
+						util::warn("failed to download cover art (status %d)", r.status_code);
+					}
+				}
+			}
 
 			if(!cover.empty())
 			{

--- a/source/tagging/metadata/moviedb.cpp
+++ b/source/tagging/metadata/moviedb.cpp
@@ -195,6 +195,9 @@ namespace tag::moviedb
 			ret.dbTitle         = data.get("title").get<std::string>();
 			ret.originalTitle   = data.get("original_title").get<std::string>();
 			ret.airDate         = data.get("release_date").get<std::string>();
+
+			if(auto poster = data.get("poster_path"); !poster.is<pj::null>())
+				ret.coverUrl = zpr::sprint("https://image.tmdb.org/t/p/original%s", poster.get<std::string>());
 			{
 				std::smatch sm;
 				std::regex_match(ret.airDate, sm, std::regex("(\\d+)-(\\d+)-(\\d+)"));

--- a/source/tagging/metadata/tvmaze.cpp
+++ b/source/tagging/metadata/tvmaze.cpp
@@ -177,6 +177,12 @@ namespace tag::tvmaze
 				return x.as_str();
 			});
 
+			if(auto img = data["image"]; !img.is<pj::null>())
+			{
+				if(auto orig = img.get("original"); !orig.is<pj::null>())
+					ret.coverUrl = orig.as_str();
+			}
+
 			// actors come from elsewhere:
 			{
 				auto r = cpr::Get(
@@ -286,6 +292,7 @@ namespace tag::tvmaze
 				ret.dbName = epName.get<std::string>();
 
 			ret.actors = ret.seriesMeta.actors;
+			ret.coverUrl = ret.seriesMeta.coverUrl;
 			ret.name = ret.dbName;
 
 			if(config::isOverridingEpisodeName() && !title.empty())


### PR DESCRIPTION
# Add cover art download support from metadata APIs

## Summary

This PR adds the ability to automatically download cover art from metadata providers (TVMaze, TheMovieDB) when tagging MKV files. Two new command-line options control this behavior:

- `--download-cover` - Downloads cover art only when no local sidecar image exists AND the MKV has no embedded cover
- `--force-download-cover` - Always downloads cover art, replacing any existing local or embedded cover

## Changes

### Metadata Provider Updates

**TVMaze** (`source/tagging/metadata/tvmaze.cpp`):
- Extracts the `image.original` URL from series metadata
- Propagates cover URL from series metadata to episode metadata

**TheMovieDB** (`source/tagging/metadata/moviedb.cpp`):
- Extracts `poster_path` from movie metadata
- Constructs full URL: `https://image.tmdb.org/t/p/original{poster_path}`

### Tagging Logic (`source/tagging/driver.cpp`)

Added download workflow:
1. Check if download is appropriate based on flags and existing covers
2. Fetch image via HTTP (using cpr library)
3. Save to temporary file (`.tmp-mkvinator-cover.{jpg,png}`)
4. Embed as attachment via existing cover art logic
5. Clean up temporary file

## Subtle Behavior Change: `--no-smart-replace-cover-art` Interaction

This PR includes a subtle but important refactor to how existing cover art is detected.

### Previous Behavior

```cpp
if(!config::disableSmartReplaceCoverArt() && util::match(attachment.mime, "image/jpeg", "image/png")
    && util::match(attachment.name, "cover", "cover.jpg", ...))
{
    attachment.doNotReattach = true;
}
```

The `disableSmartReplaceCoverArt` flag controlled **both**:
1. Whether to detect an existing attachment as cover art
2. Whether to skip extracting/reattaching it

This meant with `--no-smart-replace-cover-art`, the code couldn't tell if a file already had embedded cover art.

### New Behavior

```cpp
if(util::match(attachment.mime, "image/jpeg", "image/png")
    && util::match(attachment.name, "cover", "cover.jpg", ...))
{
    attachment.isCoverArt = true;  // Always detect
    if(!config::disableSmartReplaceCoverArt())
        attachment.doNotReattach = true;  // Only affects reattach behavior
}
```

Now detection and reattach behavior are decoupled:
- `isCoverArt` is **always** set when an existing cover is found
- `doNotReattach` is only set when smart replace is enabled

### Why This Matters

The download logic needs to know if a file already has embedded cover art:

```cpp
else if(cover.empty() && !firstAttachment.isCoverArt)
{
    // no local sidecar AND no existing cover in MKV
    shouldDownload = true;
}
```

With the old code, using `--no-smart-replace-cover-art` would have caused `--download-cover` to unnecessarily download covers for files that already had them embedded (because `isCoverArt` would never be set).

The refactor ensures `--download-cover` correctly respects existing embedded covers regardless of the `--no-smart-replace-cover-art` setting.