### PR TITLE
Fix movie filename parsing with trailing content after year

### DIFF
--- a/source/tagging/nameparser.cpp
+++ b/source/tagging/nameparser.cpp
@@ -122,7 +122,7 @@ namespace tag
 		std::string title;
 		int year = 0;
 
-		auto regex = std::regex("(.+?) \\((\\d+)\\)");
+		auto regex = std::regex("(.+?) \\((\\d+)\\)(?:.*)");
 		{
 			std::smatch sm;
 			std::regex_match(filename, sm, regex);


### PR DESCRIPTION
Filenames like `Title (2024) (Alternate Title).mkv` failed to parse because the regex required the string to end after `(year)`. Adding `(?:.*)` allows optional trailing content.