### PR TITLE
Add --match-movie-year option for filtering movie search by year

### DIFF
--- a/source/arguments.cpp
+++ b/source/arguments.cpp
@@ -42,6 +42,7 @@ static constexpr const char* VERSION = "1.4.3";
 #define ARG_PREFER_SIGN_SONG_SUBS           "--prefer-signs-songs-subs"
 #define ARG_NO_SMART_REPLACE_COVER          "--no-smart-replace-cover-art"
 #define ARG_RENAME_WITH_EPISODE_TITLE       "--rename-with-episode-title"
+#define ARG_MATCH_MOVIE_YEAR                "--match-movie-year"
 
 #define ARG_MOVIE_ID                        "--movie-id"
 #define ARG_SERIES_ID                       "--series-id"
@@ -108,6 +109,10 @@ static void setupMap()
 
 	helpList.push_back({ ARG_MOVIE_ID,
 		"specify the movie id (moviedb) (implies movie -- disables tv matching)"
+	});
+
+	helpList.push_back({ ARG_MATCH_MOVIE_YEAR,
+		"filter movie search results by year parsed from filename (moviedb)"
 	});
 
 	helpList.push_back({ ARG_AUDIO_LANGS,
@@ -535,6 +540,11 @@ namespace args
 				else if(!strcmp(argv[i], ARG_NO_MOVIE))
 				{
 					config::setDisableMovieSearch(true);
+					continue;
+				}
+				else if(!strcmp(argv[i], ARG_MATCH_MOVIE_YEAR))
+				{
+					config::setMatchMovieYear(true);
 					continue;
 				}
 				else if(!strcmp(argv[i], ARG_RENAME_WITH_EPISODE_TITLE))

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -256,6 +256,7 @@ namespace config
 	static bool skipNCOPNCED = false;
 	static bool noSeriesSearch = false;
 	static bool noMovieSearch = false;
+	static bool matchMovieYear = false;
 	static bool preferEnglishTitle = false;
 	static bool noSmartReplaceCoverArt = false;
 	static bool renameWithoutEpisodeTitle = false;
@@ -315,6 +316,7 @@ namespace config
 	bool shouldSkipNCOPNCED()               { return skipNCOPNCED; }
 	bool disableSeriesSearch()              { return noSeriesSearch; }
 	bool disableMovieSearch()               { return noMovieSearch; }
+	bool shouldMatchMovieYear()             { return matchMovieYear; }
 	int getSeasonNumber()                   { return manualSeasonNumber; }
 	int getEpisodeNumber()                  { return manualEpisodeNumber; }
 	double getSubtitleDelay()               { return subtitleDelay; }
@@ -350,6 +352,7 @@ namespace config
 	void setSkipNCOPNCED(bool x)                    { skipNCOPNCED = x; }
 	void setDisableSeriesSearch(bool x)             { noSeriesSearch = x; }
 	void setDisableMovieSearch(bool x)              { noMovieSearch = x; }
+	void setMatchMovieYear(bool x)                  { matchMovieYear = x; }
 	void setSeasonNumber(int x)                     { manualSeasonNumber = x; }
 	void setEpisodeNumber(int x)                    { manualEpisodeNumber = x; }
 	void setSubtitleDelay(double x)                 { subtitleDelay = x; }

--- a/source/include/defs.h
+++ b/source/include/defs.h
@@ -226,6 +226,7 @@ namespace config
 
 	bool disableSeriesSearch();
 	bool disableMovieSearch();
+	bool shouldMatchMovieYear();
 
 	bool isDryRun();
 	bool disableProgress();
@@ -255,6 +256,7 @@ namespace config
 	void setSkipNCOPNCED(bool x);
 	void setDisableSeriesSearch(bool x);
 	void setDisableMovieSearch(bool x);
+	void setMatchMovieYear(bool x);
 	void setSeasonNumber(int x);
 	void setEpisodeNumber(int x);
 

--- a/source/tagging/metadata/moviedb.cpp
+++ b/source/tagging/metadata/moviedb.cpp
@@ -27,14 +27,18 @@ namespace tag::moviedb
 			// note: there's no need to cache this, since we don't do multiple movies
 			// with the same title (what's the point of that?) unlike tv shows.
 
+			cpr::Parameters params = {
+				{ "api_key", getToken() },
+				{ "query", title },
+				{ "include_adult", true }
+			};
+
+			if(config::shouldMatchMovieYear() && year > 0)
+				params.AddParameter({ "year", std::to_string(year) });
+
 			auto r = cpr::Get(
 				cpr::Url(zpr::sprint("%s/search/movie", API_URL)),
-				cpr::Parameters({
-					{ "api_key", getToken() },
-					{ "query", title },
-					// { "year", year },
-					{ "include_adult", true }
-				})
+				params
 			);
 
 			if(r.status_code != 200)


### PR DESCRIPTION
# Add --match-movie-year option for filtering movie search by year

## Summary

This PR adds a new command-line option `--match-movie-year` that filters movie search results by the year parsed from the filename. When enabled, TheMovieDB API's `year` parameter is used for server-side filtering, reducing the number of results and potentially allowing automatic tagging without user interaction. When tagging movies, filenames might include the release year (e.g., `Movie Title (2024).mkv`). Previously, this year was parsed from the filename but never used in the search query. If multiple movies share similar titles, users had to manually select from a list of results. When you're tagging hundreds of mkv files, all this manual confirmation becomes a headache. With `--match-movie-year`, the parsed year is sent to TheMovieDB API, which filters results server-side. If only one movie matches the title and year, tagging proceeds automatically.

## Changes

The year parameter was already accepted by `fetchMovieMetadata()` but was commented out in the API call:

```cpp
// Before (commented out, never sent)
cpr::Parameters({
    { "api_key", getToken() },
    { "query", title },
    // { "year", year },
    { "include_adult", true }
})
```

```cpp
// After (conditionally sent)
cpr::Parameters params = {
    { "api_key", getToken() },
    { "query", title },
    { "include_adult", true }
};

if(config::shouldMatchMovieYear() && year > 0)
    params.AddParameter({ "year", std::to_string(year) });
```

The check `year > 0` ensures we only filter when a valid year was actually parsed from the filename.